### PR TITLE
Add: postgresqlに変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ src/config/credentials/production.key
 
 # dockercomposeファイルで指定したファイル。管理不要。
 src/db/mysql_data
+
+tmp/db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,20 +3,20 @@ version: "3"
 
 # 2つのサービスを定義
 services:
-  # mysql
+  # postgres
   db:
     # ベースイメージ
-    image: mysql:8.0
-    # mysqlの認証形式が変わったためにこのコマンドを打たないとエラーになる
-    command: --default-authentication-plugin=mysql_native_password
+    image: postgres:latest
+
     # ローカルのデータをdockerのディレクトリに同期する(コンテナが消えるたびにデータが消えちゃう)
     # 開発を楽にするために実施
     volumes:
-      - ./src/db/mysql_data:/var/lib/mysql
-
+      - ./tmp/db:/var/lib/postgresql/data
     # 環境変数の設定(パスワード)
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: proadmaps_development
 
   # rails
   web:

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -7,7 +7,7 @@ ruby "3.1.2"
 gem "rails", "~> 7.0.4"
 
 # Use mysql as the database for Active Record
-gem "mysql2", "~> 0.5"
+gem "pg", "~> 1.1"
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -101,7 +101,6 @@ GEM
     mini_mime (1.1.2)
     minitest (5.16.3)
     msgpack (1.6.0)
-    mysql2 (0.5.4)
     net-imap (0.3.1)
       net-protocol
     net-pop (0.1.2)
@@ -115,6 +114,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.9-arm64-darwin)
       racc (~> 1.4)
+    pg (1.4.4)
     puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -170,7 +170,7 @@ DEPENDENCIES
   bootsnap
   debug
   jwt
-  mysql2 (~> 0.5)
+  pg (~> 1.1)
   puma (~> 5.0)
   rack-cors
   rails (~> 7.0.4)

--- a/src/config/database.yml
+++ b/src/config/database.yml
@@ -1,32 +1,66 @@
-# MySQL. Versions 5.5.8 and up are supported.
+# PostgreSQL. Versions 9.3 and up are supported.
 #
-# Install the MySQL driver
-#   gem install mysql2
+# Install the pg driver:
+#   gem install pg
+# On macOS with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On macOS with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
 #
-# Ensure the MySQL gem is defined in your Gemfile
-#   gem "mysql2"
-#
-# And be sure to use new-style password hashing:
-#   https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html
+# Configure Using Gemfile
+# gem "pg"
 #
 default: &default
-  adapter: mysql2
-  encoding: utf8mb4
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see Rails configuration guide
+  # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: root
+  username: postgres
   password: password
   host: db
 
 development:
   <<: *default
-  database: app_development
+  database: proadmaps_development
+
+  # The specified database role being used to connect to postgres.
+  # To create additional roles in postgres see `$ createuser --help`.
+  # When left blank, postgres will use the default role. This is
+  # the same name as the operating system user running Rails.
+  #username: app
+
+  # The password associated with the postgres role (username).
+  #password:
+
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  #host: localhost
+
+  # The TCP port the server listens on. Defaults to 5432.
+  # If your server runs on a different port number, change accordingly.
+  #port: 5432
+
+  # Schema search path. The server defaults to $user,public
+  #schema_search_path: myapp,sharedapp,public
+
+  # Minimum log levels, in increasing order:
+  #   debug5, debug4, debug3, debug2, debug1,
+  #   log, notice, warning, error, fatal, and panic
+  # Defaults to warning.
+  #min_messages: notice
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: app_test
+  database: proadmaps_test
   host: <%= ENV.fetch("APP_DATABASE_HOST") { 'db' } %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
@@ -36,7 +70,7 @@ test:
 # Instead, provide the password or a full connection URL as an environment
 # variable when you boot the app. For example:
 #
-#   DATABASE_URL="mysql2://myuser:mypass@localhost/somedatabase"
+#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
 #
 # If the connection URL is provided in the special DATABASE_URL environment
 # variable, Rails will automatically merge its configuration values on top of
@@ -51,7 +85,6 @@ test:
 #
 production:
   <<: *default
-  database: <%= ENV['APP_DATABASE'] %>
-  username: <%= ENV['APP_DATABASE_USERNAME'] %>
-  password: <%= ENV['APP_DATABASE_PASSWORD'] %>
-  host: <%= ENV['APP_DATABASE_HOST'] %>
+  # url: <%= ENV['DATABASE_URL'] %>
+  database: proadmaps_production
+  password: <%= ENV["POSTGRES_PASSWORD"] %>

--- a/src/config/initializers/cors.rb
+++ b/src/config/initializers/cors.rb
@@ -8,7 +8,7 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     if Rails.env.production?
-      origins "https://proadmaps.vercel.app"
+      origins "https://proadmaps.com"
     else
       origins "http://localhost:9000"
     end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -11,7 +11,10 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2022_11_12_120410) do
-  create_table "likes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "likes", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "roadmap_id", null: false
     t.datetime "created_at", null: false
@@ -21,7 +24,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_12_120410) do
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
-  create_table "roadmap_tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "roadmap_tags", force: :cascade do |t|
     t.bigint "roadmap_id", null: false
     t.bigint "tag_id", null: false
     t.datetime "created_at", null: false
@@ -31,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_12_120410) do
     t.index ["tag_id"], name: "index_roadmap_tags_on_tag_id"
   end
 
-  create_table "roadmaps", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "roadmaps", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "title", null: false
     t.text "introduction"
@@ -43,7 +46,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_12_120410) do
     t.index ["user_id"], name: "index_roadmaps_on_user_id"
   end
 
-  create_table "steps", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "steps", force: :cascade do |t|
     t.bigint "roadmap_id", null: false
     t.text "url"
     t.string "title", null: false
@@ -57,13 +60,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_12_120410) do
     t.index ["roadmap_id"], name: "index_steps_on_roadmap_id"
   end
 
-  create_table "tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "tags", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "users", force: :cascade do |t|
     t.string "sub", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
外部にリリースするのはherokuに乗っけたものにする。その際に、mysqlが有料になるのか、どういう立ち位置なのかわからなかったため、postgresqlにする。
別途、就活向けにECSに乗っけるものを作成する。